### PR TITLE
Redis cache is added.

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="56c1f33f-94b3-4a21-9790-e6037ec19148" name="Changes" comment=".gitignore is changed.">
+      <change beforePath="$PROJECT_DIR$/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/service/MusicTempStorageService.java" beforeDir="false" afterPath="$PROJECT_DIR$/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/service/MusicTempStorageService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/service/impl/MusicServiceImpl.java" beforeDir="false" afterPath="$PROJECT_DIR$/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/service/impl/MusicServiceImpl.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/service/impl/MusicTempMapStorageServiceImpl.java" beforeDir="false" afterPath="$PROJECT_DIR$/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/service/impl/MusicTempMapStorageServiceImpl.java" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_BRANCH_BY_REPOSITORY">
+      <map>
+        <entry key="$PROJECT_DIR$" value="master" />
+      </map>
+    </option>
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="MarkdownSettingsMigration">
+    <option name="stateVersion" value="1" />
+  </component>
+  <component name="ProjectId" id="2ZddhMKnqBNoRNAbS7WdEy10Wli" />
+  <component name="ProjectLevelVcsManager" settingsEditedManually="true" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "WebServerToolWindowFactoryState": "false",
+    "spring.configuration.checksum": "0215526b41ab83ac1584e3421f8cf37b"
+  }
+}]]></component>
+  <component name="RunManager">
+    <configuration name="MusicfinderbotApplication" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" nameIsGenerated="true">
+      <module name="musicfinderbot" />
+      <option name="SPRING_BOOT_MAIN_CLASS" value="uz.sardorbroo.musicfinderbot.MusicfinderbotApplication" />
+      <method v="2">
+        <option name="Make" enabled="true" />
+      </method>
+    </configuration>
+  </component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="56c1f33f-94b3-4a21-9790-e6037ec19148" name="Changes" comment=".gitignore is changed." />
+      <created>1702756011017</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1702756011017</updated>
+      <workItem from="1702756012272" duration="2342000" />
+    </task>
+    <servers />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,15 +4,29 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="56c1f33f-94b3-4a21-9790-e6037ec19148" name="Changes" comment=".gitignore is changed.">
-      <change beforePath="$PROJECT_DIR$/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/service/MusicTempStorageService.java" beforeDir="false" afterPath="$PROJECT_DIR$/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/service/MusicTempStorageService.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/service/impl/MusicServiceImpl.java" beforeDir="false" afterPath="$PROJECT_DIR$/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/service/impl/MusicServiceImpl.java" afterDir="false" />
+    <list default="true" id="56c1f33f-94b3-4a21-9790-e6037ec19148" name="Changes" comment="Temporary storage service(interface) is added. Musics name adds when user downloads the music">
+      <change afterPath="$PROJECT_DIR$/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/config/CacheConfiguration.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/config/constants/CacheType.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/service/impl/MusicTempRedisStorageServiceImpl.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/util/StringMaskUtils.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/musicfinderbot/src/main/music-finder-docker/redis.yml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/musicfinderbot/pom.xml" beforeDir="false" afterPath="$PROJECT_DIR$/musicfinderbot/pom.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/service/dto/MusicDTO.java" beforeDir="false" afterPath="$PROJECT_DIR$/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/service/dto/MusicDTO.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/service/impl/MusicTempMapStorageServiceImpl.java" beforeDir="false" afterPath="$PROJECT_DIR$/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/service/impl/MusicTempMapStorageServiceImpl.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/musicfinderbot/src/main/resources/application.properties" beforeDir="false" afterPath="$PROJECT_DIR$/musicfinderbot/src/main/resources/application.properties" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
     <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="FileTemplateManagerImpl">
+    <option name="RECENT_TEMPLATES">
+      <list>
+        <option value="Class" />
+      </list>
+    </option>
   </component>
   <component name="Git.Settings">
     <option name="RECENT_BRANCH_BY_REPOSITORY">
@@ -31,15 +45,24 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "RunOnceActivity.OpenProjectViewOnStart": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "WebServerToolWindowFactoryState": "false",
-    "spring.configuration.checksum": "0215526b41ab83ac1584e3421f8cf37b"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;RequestMappingsPanelOrder0&quot;: &quot;0&quot;,
+    &quot;RequestMappingsPanelOrder1&quot;: &quot;1&quot;,
+    &quot;RequestMappingsPanelWidth0&quot;: &quot;75&quot;,
+    &quot;RequestMappingsPanelWidth1&quot;: &quot;75&quot;,
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;WebServerToolWindowFactoryState&quot;: &quot;false&quot;,
+    &quot;spring.configuration.checksum&quot;: &quot;0215526b41ab83ac1584e3421f8cf37b&quot;
   }
-}]]></component>
-  <component name="RunManager">
+}</component>
+  <component name="RecentsManager">
+    <key name="CopyClassDialog.RECENTS_KEY">
+      <recent name="uz.sardorbroo.musicfinderbot.util" />
+    </key>
+  </component>
+  <component name="RunManager" selected="Spring Boot.MusicfinderbotApplication">
     <configuration name="MusicfinderbotApplication" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" nameIsGenerated="true">
       <module name="musicfinderbot" />
       <option name="SPRING_BOOT_MAIN_CLASS" value="uz.sardorbroo.musicfinderbot.MusicfinderbotApplication" />
@@ -47,6 +70,30 @@
         <option name="Make" enabled="true" />
       </method>
     </configuration>
+    <configuration default="true" type="docker-deploy" factoryName="docker-compose.yml" temporary="true">
+      <deployment type="docker-compose.yml">
+        <settings />
+      </deployment>
+      <method v="2" />
+    </configuration>
+    <configuration name="music-finder-docker/redis.yml.redis: Compose Deployment" type="docker-deploy" factoryName="docker-compose.yml" temporary="true" server-name="Docker">
+      <deployment type="docker-compose.yml">
+        <settings>
+          <option name="services">
+            <list>
+              <option value="redis" />
+            </list>
+          </option>
+          <option name="sourceFilePath" value="musicfinderbot/src/main/music-finder-docker/redis.yml" />
+        </settings>
+      </deployment>
+      <method v="2" />
+    </configuration>
+    <recent_temporary>
+      <list>
+        <item itemvalue="Docker.music-finder-docker/redis.yml.redis: Compose Deployment" />
+      </list>
+    </recent_temporary>
   </component>
   <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
   <component name="TaskManager">
@@ -56,8 +103,37 @@
       <option name="number" value="Default" />
       <option name="presentableId" value="Default" />
       <updated>1702756011017</updated>
-      <workItem from="1702756012272" duration="2342000" />
+      <workItem from="1702756012272" duration="3914000" />
+      <workItem from="1702859888048" duration="8739000" />
     </task>
+    <task id="LOCAL-00001" summary="Temporary storage service(interface) is added. Musics name adds when user downloads the music">
+      <created>1702759259516</created>
+      <option name="number" value="00001" />
+      <option name="presentableId" value="LOCAL-00001" />
+      <option name="project" value="LOCAL" />
+      <updated>1702759259516</updated>
+    </task>
+    <option name="localTasksCounter" value="2" />
     <servers />
+  </component>
+  <component name="VcsManagerConfiguration">
+    <MESSAGE value="Temporary storage service(interface) is added. Musics name adds when user downloads the music" />
+    <option name="LAST_COMMIT_MESSAGE" value="Temporary storage service(interface) is added. Musics name adds when user downloads the music" />
+  </component>
+  <component name="XDebuggerManager">
+    <breakpoint-manager>
+      <breakpoints>
+        <line-breakpoint enabled="true" type="java-line">
+          <url>file://$PROJECT_DIR$/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/service/utils/UserUtils.java</url>
+          <line>18</line>
+          <option name="timeStamp" value="1" />
+        </line-breakpoint>
+        <line-breakpoint enabled="true" type="java-line">
+          <url>file://$PROJECT_DIR$/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/service/utils/service/impl/MessageUserExtractor.java</url>
+          <line>17</line>
+          <option name="timeStamp" value="2" />
+        </line-breakpoint>
+      </breakpoints>
+    </breakpoint-manager>
   </component>
 </project>

--- a/musicfinderbot/pom.xml
+++ b/musicfinderbot/pom.xml
@@ -18,32 +18,34 @@
 
     <properties>
         <java.version>17</java.version>
+        <jedis.version>4.3.1</jedis.version>
     </properties>
 
     <dependencies>
         <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>${jedis.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>io.github.nurislom373</groupId>
             <artifactId>spring-boot-starter-fluent</artifactId>
             <version>1.0.1</version>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/config/CacheConfiguration.java
+++ b/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/config/CacheConfiguration.java
@@ -1,0 +1,37 @@
+package uz.sardorbroo.musicfinderbot.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import redis.clients.jedis.JedisPooled;
+import uz.sardorbroo.musicfinderbot.config.constants.CacheType;
+import uz.sardorbroo.musicfinderbot.util.StringMaskUtils;
+
+@Slf4j
+@Configuration
+public class CacheConfiguration {
+
+    @Value("${cache.server.host:127.0.0.1}")
+    private String host;
+
+    @Value("${cache.server.port:6379}")
+    private Integer port;
+
+    @Bean
+    @ConditionalOnProperty(prefix = "cache.storage", name = "type", havingValue = CacheType.REDIS)
+    public JedisPooled jedisCacheClientInstance() {
+        log.info("Initializing jedis pooled... Host & Port: {}", getMaskedHostAndPort());
+
+        JedisPooled pool = new JedisPooled(host, port);
+
+        log.info("Jedis pooled is initialized successfully!");
+        return pool;
+    }
+
+    private String getMaskedHostAndPort() {
+
+        return String.join(" ", StringMaskUtils.mask(host), StringMaskUtils.mask(String.valueOf(port)));
+    }
+}

--- a/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/config/constants/CacheType.java
+++ b/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/config/constants/CacheType.java
@@ -1,0 +1,8 @@
+package uz.sardorbroo.musicfinderbot.config.constants;
+
+public class CacheType {
+
+    public static final String JAVA_MAP = "JAVA_MAP";
+    public static final String REDIS = "REDIS";
+
+}

--- a/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/service/MusicTempStorageService.java
+++ b/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/service/MusicTempStorageService.java
@@ -7,8 +7,8 @@ import java.util.UUID;
 
 public interface MusicTempStorageService {
 
-    Optional<UUID> save(MusicDTO music);
+    Optional<String> save(MusicDTO music);
 
-    Optional<MusicDTO> getById(UUID musicId);
+    Optional<MusicDTO> getById(String musicId);
 
 }

--- a/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/service/dto/MusicDTO.java
+++ b/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/service/dto/MusicDTO.java
@@ -1,11 +1,15 @@
 package uz.sardorbroo.musicfinderbot.service.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
 
 import java.util.Objects;
 
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 @Accessors(chain = true)
 public class MusicDTO {
 

--- a/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/service/impl/MusicTempMapStorageServiceImpl.java
+++ b/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/service/impl/MusicTempMapStorageServiceImpl.java
@@ -2,14 +2,20 @@ package uz.sardorbroo.musicfinderbot.service.impl;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
+import uz.sardorbroo.musicfinderbot.config.constants.CacheType;
 import uz.sardorbroo.musicfinderbot.service.MusicTempStorageService;
 import uz.sardorbroo.musicfinderbot.service.dto.MusicDTO;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 @Slf4j
 @Service
+@ConditionalOnProperty(prefix = "cache.storage", name = "type", havingValue = CacheType.JAVA_MAP)
 public class MusicTempMapStorageServiceImpl implements MusicTempStorageService {
 
     private static final Map<String, MusicDTO> MUSICS_STORAGE = new HashMap<>();

--- a/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/service/impl/MusicTempMapStorageServiceImpl.java
+++ b/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/service/impl/MusicTempMapStorageServiceImpl.java
@@ -1,6 +1,7 @@
 package uz.sardorbroo.musicfinderbot.service.impl;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 import uz.sardorbroo.musicfinderbot.service.MusicTempStorageService;
 import uz.sardorbroo.musicfinderbot.service.dto.MusicDTO;
@@ -11,30 +12,28 @@ import java.util.*;
 @Service
 public class MusicTempMapStorageServiceImpl implements MusicTempStorageService {
 
-    private static final Map<UUID, MusicDTO> MUSICS_STORAGE = new HashMap<>();
+    private static final Map<String, MusicDTO> MUSICS_STORAGE = new HashMap<>();
 
     @Override
-    public Optional<UUID> save(MusicDTO music) {
+    public Optional<String> save(MusicDTO music) {
         log.debug("Save musics to temp Map storage");
 
-        if (Objects.isNull(music)) {
-            log.warn("Invalid argument is passed! MusicDTO must not be null!");
+        if (Objects.isNull(music) || StringUtils.isBlank(music.getId())) {
+            log.warn("Invalid argument is passed! MusicDTO.ID must not be empty!");
             return Optional.empty();
         }
 
-        UUID key4Music = UUID.randomUUID();
+        MUSICS_STORAGE.put(music.getId(), music);
 
-        MUSICS_STORAGE.put(key4Music, music);
-
-        return Optional.of(key4Music);
+        return Optional.of(music.getId());
     }
 
     @Override
-    public Optional<MusicDTO> getById(UUID musicId) {
+    public Optional<MusicDTO> getById(String musicId) {
         log.debug("Get stored music by ID! ID: {}", musicId);
 
-        if (Objects.isNull(musicId)) {
-            log.warn("Invalid argument is passed! MusicID must not be null!");
+        if (StringUtils.isBlank(musicId)) {
+            log.warn("Invalid argument is passed! MusicID must not be empty!");
             return Optional.empty();
         }
 

--- a/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/service/impl/MusicTempRedisStorageServiceImpl.java
+++ b/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/service/impl/MusicTempRedisStorageServiceImpl.java
@@ -1,0 +1,94 @@
+package uz.sardorbroo.musicfinderbot.service.impl;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+import redis.clients.jedis.JedisPooled;
+import uz.sardorbroo.musicfinderbot.config.constants.CacheType;
+import uz.sardorbroo.musicfinderbot.service.MusicTempStorageService;
+import uz.sardorbroo.musicfinderbot.service.dto.MusicDTO;
+
+import java.util.Objects;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@ConditionalOnProperty(prefix = "cache.storage", name = "type", havingValue = CacheType.REDIS)
+public class MusicTempRedisStorageServiceImpl implements MusicTempStorageService {
+
+    private final JedisPooled jedis;
+    private final ObjectMapper mapper;
+
+    @Value("${cache.storage.ttl:300}") // 300 second = 5 min
+    private long time2LiveInSecond;
+
+    public MusicTempRedisStorageServiceImpl(JedisPooled jedis, ObjectMapper mapper) {
+        this.jedis = jedis;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public Optional<String> save(MusicDTO music) {
+        log.debug("Caching music with Jedis");
+
+        if (Objects.isNull(music) || StringUtils.isBlank(music.getId())) {
+            log.warn("Invalid argument is passed! Music.ID must not be empty!");
+            return Optional.empty();
+        }
+
+        Optional<String> musicOptional = convert(music);
+        if (musicOptional.isEmpty()) {
+            log.warn("Music is not converted to String!");
+            return Optional.empty();
+        }
+
+        String musicId = jedis.setex(music.getId(), time2LiveInSecond, musicOptional.get());
+
+        log.debug("Music is cached successfully. Cache ID: {}", musicId);
+        return Optional.of(musicId);
+    }
+
+    @Override
+    public Optional<MusicDTO> getById(String musicId) {
+        log.debug("Get cached object by ID: {}", musicId);
+
+        if (StringUtils.isBlank(musicId)) {
+            log.warn("Invalid argument is passed! MusicID must not be empty!");
+            return Optional.empty();
+        }
+
+        return getCachedMusic(musicId);
+    }
+
+    private Optional<MusicDTO> getCachedMusic(String musicId) {
+
+        String musicAsString = jedis.get(musicId);
+        return convert(musicAsString);
+    }
+
+    private Optional<MusicDTO> convert(String musicAsString) {
+
+        try {
+            MusicDTO music = mapper.readValue(musicAsString, new TypeReference<MusicDTO>() {});
+            return Optional.of(music);
+        } catch (Exception e) {
+            log.warn("Cached object type not MusicDTO! Exception: {}", e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private Optional<String> convert(MusicDTO music) {
+
+        try {
+            String musicAsString = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(music);
+            return Optional.of(musicAsString);
+        } catch (Exception e) {
+            log.warn("Error while converting MusicDTO to String! Exception: {}", e.getMessage());
+            return Optional.empty();
+        }
+    }
+}

--- a/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/service/utils/service/impl/CallbackQueryUserExtractor.java
+++ b/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/service/utils/service/impl/CallbackQueryUserExtractor.java
@@ -23,6 +23,6 @@ public class CallbackQueryUserExtractor implements UserExtractor {
     }
 
     private boolean isMessageUserNull(Update update) {
-        return Objects.nonNull(update) && Objects.nonNull(update.getMessage()) && Objects.nonNull(update.getMessage().getFrom());
+        return Objects.nonNull(update) && Objects.nonNull(update.getCallbackQuery()) && Objects.nonNull(update.getCallbackQuery().getFrom());
     }
 }

--- a/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/util/StringMaskUtils.java
+++ b/musicfinderbot/src/main/java/uz/sardorbroo/musicfinderbot/util/StringMaskUtils.java
@@ -1,0 +1,18 @@
+package uz.sardorbroo.musicfinderbot.util;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class StringMaskUtils {
+    private static final Integer MASKING_LENGTH = 12;
+    private static final Integer MIN_LENGTH_ABBREVIATION = 4;
+
+    public static String mask(String target) {
+
+        if (StringUtils.isBlank(target)) {
+            return "";
+        }
+
+        final int countOfMaskingSymbols = target.length() < MASKING_LENGTH ? MIN_LENGTH_ABBREVIATION : MASKING_LENGTH;
+        return StringUtils.abbreviate(target, countOfMaskingSymbols);
+    }
+}

--- a/musicfinderbot/src/main/music-finder-docker/redis.yml
+++ b/musicfinderbot/src/main/music-finder-docker/redis.yml
@@ -1,0 +1,7 @@
+version: '3.8'
+services:
+  redis:
+    container_name: redis-cache-server
+    image: redis/redis-stack-server
+    ports:
+      - 6379:6379

--- a/musicfinderbot/src/main/resources/application.properties
+++ b/musicfinderbot/src/main/resources/application.properties
@@ -8,3 +8,5 @@ music.service.simulate=false
 music.service.credentials.secret=8548e804bemsh709a62e40d33426p112a40jsneb42cd2e710e
 music.service.spotify.url=https://spotify23.p.rapidapi.com
 music.service.spotify.simulate=false
+
+cache.storage.type=REDIS


### PR DESCRIPTION
MusicFinderBot can work with Redis Cache Server. Temporary services are implemented. There are 2 implementation **MusicTempMapStorageServiceImpl** and **MusicRedisMapStorageServiceImpl**. If choose `REDIS` for `cache.storage.type` key in **application.properties** then **MusicRedisMapStorageServiceImpl** will work, if choose `JAVA_MAP` then **MusicTempMapStorageServiceImpl** will work.

If you want to enable Redis cache server, you should run `src/main/music-finder-docker/redis.yml` 